### PR TITLE
move oneOf types to src/types, add docs

### DIFF
--- a/doc/.vuepress/config.ts
+++ b/doc/.vuepress/config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
           "data_types/size",
           "data_types/string",
           "data_types/struct",
+          "data_types/one-of",
           "data_types/array",
           "data_types/map",
           "data_types/optional",

--- a/doc/data_types/one-of.md
+++ b/doc/data_types/one-of.md
@@ -1,0 +1,111 @@
+# OneOf
+
+OneOf allows you to serialize and deserialize a value of a union type, that is,
+a value that can be of one of the multiple types. `sd.oneOf` takes
+a definition object whose keys are names of possible types of a value,
+and values are `sd.Serdes<T>` which are used to encode and decode
+values of that type.
+
+`sd.oneOf` maps each type to unique integer and writes it at the
+beginning of the payload to differentiate between types. It's first
+parameter is `headSd`, which is `sd.Serdes<number>` used to encode the
+unique integer
+
+The following `sd.oneOf` call:
+
+```ts
+const oneOf = sd.oneOf(sd.uint8, {
+  a: sd.uint8,
+  b: sd.array(sd.uint8, sd.uint8),
+
+  foo: sd.struct({
+    x: sd.float64,
+    y: sd.float64
+  })
+});
+```
+
+will create `sd.Serdes<U>`, where `U` is a union type:
+
+```ts
+type U = {
+  type: "a";
+  value: number;
+} | {
+  type: "b";
+  value: number[];
+} | {
+  type: "foo";
+  value: {
+    x: number;
+    y: number;
+  };
+};
+```
+
+And types "a", "b" and "foo" will be mapped to unique integer encoded
+by `sd.uint8`
+
+## Usage
+
+```ts
+const oneOf = sd.oneOf(sd.uint8, {
+  a: sd.uint8,
+  b: sd.array(sd.uint8, sd.uint8),
+
+  foo: sd.struct({
+    x: sd.float64,
+    y: sd.float64
+  })
+});
+
+const { toBytes, fromBytes } = sd.use(oneOf);
+
+const obj: sd.GetType<typeof oneOf> = {
+  type: "foo",
+  value: {
+    x: 42,
+    y: 42
+  }
+};
+
+const bytes = toBytes(obj);
+const result = fromBytes(bytes);
+
+switch (result.type) {
+  case "a":
+    console.log(typeof result.value); //number
+    break;
+  case "b":
+    console.log(result.value.join(", "));
+    break;
+  case "foo":
+    console.log(`x = ${result.value.x}, y = ${result.value.y}`);
+    break;
+}
+```
+
+## Specifications
+
+`sd.oneOf` first serializes integer which is used to differentiate
+different types, and then serializes a value of that type using the
+corresponding `sd.Serdes<T>` in the definition object
+
+Values of the integer are mapped to the properties of the definition
+object (that is, possible types of a value) starting from `0`, in order in which
+the properties appear on the object. So, in the example above values are mapped
+to the properties (types) like this:
+
+```
+0 -> "a"
+1 -> "b"
+2 -> "foo"
+```
+
+The payload will be in the one of the following forms:
+
+```
+[headSd 0][a value (uint8)]
+[headSd 1][b number of items (uint8)][...b items (uint8)]
+[headSd 2][c.x (float64)][c.y (float64)]
+```

--- a/src/types/factories.ts
+++ b/src/types/factories.ts
@@ -54,3 +54,20 @@ export type ArrayFactory = <T>(
 ) => Serdes<T[]>;
 
 export type OptionalFactory = <T>(sd: Serdes<T>) => Serdes<T | void>;
+
+export type OneOfMap<T> = {
+  [K in keyof T]: {
+    type: K;
+    value: T[K];
+  };
+};
+
+export type ValueOf<T> = T[keyof T];
+export type OneOf<T> = ValueOf<OneOfMap<T>>;
+
+export type OneOfFactory = <
+  T extends Record<string | number | symbol, unknown>
+>(
+  headSd: Serdes<number>,
+  definition: StructDefinition<T>
+) => Serdes<OneOf<T>>;

--- a/test/serdes/one-of.test.ts
+++ b/test/serdes/one-of.test.ts
@@ -1,91 +1,64 @@
-import { 
-  float64, 
+import {
+  float64,
   GetType,
-  string, 
-  struct, 
-  uint8, 
-  oneOf, 
-  use, 
-  utf8js, 
-  InvalidOneOfType, 
-  boolean 
+  string,
+  struct,
+  uint8,
+  oneOf,
+  use,
+  utf8js,
+  InvalidOneOfType
 } from "../../src";
 
-(() => {
-  const Vector = struct({
-    x: float64,
-    y: float64
-  });
+const Vector = struct({
+  x: float64,
+  y: float64
+});
 
-  const Nickname = string(utf8js, uint8);
+const Nickname = string(utf8js, uint8);
 
-  const Message = use(oneOf(uint8, {
+const Message = use(
+  oneOf(uint8, {
     nickname: Nickname,
     velocity: Vector
-  }));
+  })
+);
 
-  const messages: GetType<typeof Message>[] = [
-    {
-      type: "nickname",
-      value: "Foo"
-    },
+const messages: GetType<typeof Message>[] = [
+  {
+    type: "nickname",
+    value: "Foo"
+  },
 
-    {
-      type: "velocity",
-      value: { x: 42, y: 42 }
-    }
-  ];
+  {
+    type: "velocity",
+    value: { x: 42, y: 42 }
+  }
+];
 
-  test.each(messages)("Works", m => {
-    const bytes = Message.toBytes(m);
-    const decoded = Message.fromBytes(bytes);
+test.each(messages)("Works", (m) => {
+  const bytes = Message.toBytes(m);
+  const decoded = Message.fromBytes(bytes);
 
-    expect(decoded).toStrictEqual(m);
-  });
+  expect(decoded).toStrictEqual(m);
+});
 
-  test(`Throws \`${InvalidOneOfType.name}\` when oneOf type is invalid`, () => {
-    const m: GetType<typeof Message> = {
-      type: "nickname",
-      value: "A"
-    };
-
-    const bytes = Message.toBytes(m);
-
-    //Replace the type header with something invalid
-    bytes[0] = 42;
-
-    try {
-      Message.fromBytes(bytes);
-      fail();
-    }
-    catch (e) {
-      expect(e).toBeInstanceOf(InvalidOneOfType);
-      expect((e as InvalidOneOfType).type).toBe(42);
-    }
-  });
-})();
-
-test("oneOf type does not depend on order of properties of the parameter object", () => {
-  const serdes1 = use(oneOf(uint8, {
-    a: float64,
-    b: boolean,
-    c: string(utf8js, uint8)
-  }));
-
-  //Shuffle properties
-  const serdes2 = use(oneOf(uint8, {
-    b: boolean,
-    c: string(utf8js, uint8),
-    a: float64
-  }));
-
-  const m: GetType<typeof serdes1> = {
-    type: "a",
-    value: Math.PI
+test(`Throws \`${InvalidOneOfType.name}\` when oneOf type is invalid`, () => {
+  const m: GetType<typeof Message> = {
+    type: "nickname",
+    value: "A"
   };
 
-  const bytes1 = serdes1.toBytes(m);
-  const bytes2 = serdes2.toBytes(m);
+  const bytes = Message.toBytes(m);
 
-  expect(bytes1).toStrictEqual(bytes2);
+  //Replace the type header with something invalid
+  bytes[0] = 42;
+
+  try {
+    Message.fromBytes(bytes);
+    fail();
+  } catch (e) {
+    expect(e).toBeInstanceOf(InvalidOneOfType);
+    expect((e as InvalidOneOfType).type).toBe(42);
+  }
 });


### PR DESCRIPTION
I've simplified code, moved some types to `src/types`, so typedoc will generate documentation for it, and added docs page for `sd.oneOf` with hopefully clear explanation

P.S. I think #7 checks failed because I had accidentally used `npm i` instead of `yarn`