### PR TITLE
Allow require imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "exports": {
     ".": {
       "node": "./build/node.js",
-      "import": "./dist/sirdez.es.js"
+      "default": "./dist/sirdez.es.js"
     },
     "./eval": {
       "node": "./build/node_eval.js",
-      "import": "./dist/sirdez.eval.es.js"
+      "default": "./dist/sirdez.eval.es.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description
Package.json exports is not defining a file to use when you use `require` only for `import`.
This is why I changed `import` to default so it handles both as a fallback. Maybe this is not correct and it should match a different file but this works for me.

## Context:
I have a monorepo repository with a shared project imported in a react+vite project. And when I run the client in development mode I get this error: 
```
'Failed to resolve entry for package "sirdez". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." entry in "sirdez" package'
```
Maybe it's a problem in my tsconfig or vite configuration, but this PR fixes it.

Oh I almost forgot to thank you for this cool library :D 